### PR TITLE
Replace current dispatch by value dispatch.

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -14,7 +14,7 @@ CRRao.set_rng(StableRNG(123))
 ```@repl examples
 df = dataset("datasets", "mtcars")
 
-m1_1 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression());
+m1_1 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression));
 
 m1_1.fit
 
@@ -41,7 +41,7 @@ m1_1.Cooks_distance
 **Linear Regression - Ridge Prior**
 
 ```@repl examples
-m1_2 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression(),Prior_Ridge());
+m1_2 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression),Prior_Ridge());
 
 m1_2.summaries
 
@@ -53,7 +53,7 @@ m1_2.quantiles
 **Linear Regression - Laplace Prior**
 
 ```@repl examples
-m1_3 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression(),Prior_Laplace());
+m1_3 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression),Prior_Laplace());
 
 m1_3.summaries
 
@@ -63,7 +63,7 @@ m1_3.quantiles
 
 **Linear Regression - Cauchy Prior**
 ```@repl examples
-m1_4 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression(),Prior_Cauchy(),20000);
+m1_4 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression),Prior_Cauchy(),20000);
 
 m1_4.summaries
 
@@ -74,7 +74,7 @@ m1_4.quantiles
 **Linear Regression - T-Distributed Prior**
 
 ```@repl examples
-m1_5 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression(),Prior_TDist());
+m1_5 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression),Prior_TDist());
 
 m1_5.summaries
 
@@ -84,7 +84,7 @@ m1_5.quantiles
 
 **Linear Regression - Uniform Prior**
 ```@repl examples
-m1_6 = @fitmodel((MPG ~ HP + WT+Gear),df,LinearRegression(),Prior_TDist());
+m1_6 = @fitmodel((MPG ~ HP + WT+Gear),df,ModelClass(:LinearRegression),Prior_TDist());
 
 m1_6.summaries
 
@@ -97,7 +97,7 @@ m1_6.quantiles
 turnout = dataset("Zelig", "turnout")
 
 m2_1 = @fitmodel((Vote ~ Age + Race +Income + Educate)
-                       ,turnout,LogisticRegression(),Logit());
+                       ,turnout,ModelClass(:LogisticRegression),Logit());
 
 m2_1.fit
 
@@ -110,7 +110,7 @@ m2_1.AIC
 m2_1.BIC
 
 m2_2 = @fitmodel((Vote ~ Age + Race +Income + Educate)
-                       ,turnout,LogisticRegression(),Probit());
+                       ,turnout,ModelClass(:LogisticRegression),Probit());
 
 m2_2.fit
 
@@ -118,14 +118,14 @@ m2_2.BIC
 
 
 m2_3 = @fitmodel((Vote ~ Age + Race +Income + Educate)
-                       ,turnout,LogisticRegression(),Cloglog());
+                       ,turnout,ModelClass(:LogisticRegression),Cloglog());
 
 m2_3.fit
 
 m2_3.BIC
 
 m2_4 = @fitmodel((Vote ~ Age + Race +Income + Educate)
-                       ,turnout,LogisticRegression(),Cauchit());
+                       ,turnout,ModelClass(:LogisticRegression),Cauchit());
 
 m2_4.fit
 
@@ -137,28 +137,28 @@ m2_4.BIC
 
 ```@repl examples
 m2_5 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Logit(),Prior_Ridge());
+                       ,ModelClass(:LogisticRegression),Logit(),Prior_Ridge());
 
 m2_5.summaries
 
 m2_5.quantiles
 
 m2_6 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Probit(),Prior_Ridge(),1.0);
+                       ,ModelClass(:LogisticRegression),Probit(),Prior_Ridge(),1.0);
 
 m2_6.summaries
 
 m2_6.quantiles
 
 m2_7 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cloglog(),Prior_Ridge(),1.0);
+                       ,ModelClass(:LogisticRegression),Cloglog(),Prior_Ridge(),1.0);
 
 m2_7.summaries
 
 m2_7.quantiles
 
 m2_8 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cauchit(),Prior_Ridge(),1.0);
+                       ,ModelClass(:LogisticRegression),Cauchit(),Prior_Ridge(),1.0);
 
 m2_8.summaries
 
@@ -169,28 +169,28 @@ m2_8.quantiles
 **Logistic Regression - with Laplace Prior**
 ```@repl examples
 m2_9 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Logit(),Prior_Laplace());
+                       ,ModelClass(:LogisticRegression),Logit(),Prior_Laplace());
 
 m2_9.summaries
 
 m2_9.quantiles
 
 m2_10 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Probit(),Prior_Laplace());
+                       ,ModelClass(:LogisticRegression),Probit(),Prior_Laplace());
 
 m2_10.summaries
 
 m2_10.quantiles
 
 m2_11 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cloglog(),Prior_Laplace(),1.0);
+                       ,ModelClass(:LogisticRegression),Cloglog(),Prior_Laplace(),1.0);
 
 m2_11.summaries
 
 m2_11.quantiles
 
 m2_12 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cauchit(),Prior_Laplace(),1.0);
+                       ,ModelClass(:LogisticRegression),Cauchit(),Prior_Laplace(),1.0);
 
 m2_12.summaries
 
@@ -201,28 +201,28 @@ m2_12.quantiles
 **Logistic Regression - with Cauchy Prior**
 ```@repl examples
 m2_13 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Logit(),Prior_Cauchy(),1.0);
+                       ,ModelClass(:LogisticRegression),Logit(),Prior_Cauchy(),1.0);
 
 m2_13.summaries
 
 m2_13.quantiles
 
 m2_14 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Probit(),Prior_Cauchy(),2.0,30000);
+                       ,ModelClass(:LogisticRegression),Probit(),Prior_Cauchy(),2.0,30000);
 
 m2_14.summaries
 
 m2_14.quantiles
            
 m2_15 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cloglog(),Prior_Cauchy(),1.0);
+                       ,ModelClass(:LogisticRegression),Cloglog(),Prior_Cauchy(),1.0);
 
 m2_15.summaries
 
 m2_15.quantiles
               
 m2_16 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cauchit(),Prior_Cauchy(),1.0);
+                       ,ModelClass(:LogisticRegression),Cauchit(),Prior_Cauchy(),1.0);
 
 m2_16.summaries
 
@@ -233,28 +233,28 @@ m2_16.quantiles
 **Logistic Regression - with T-Dist Prior**
 ```@repl examples
 m2_17 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Logit(),Prior_TDist(),1.0);
+                       ,ModelClass(:LogisticRegression),Logit(),Prior_TDist(),1.0);
 
 m2_17.summaries
 
 m2_17.quantiles
 
 m2_18 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Probit(),Prior_TDist(),1.0);
+                       ,ModelClass(:LogisticRegression),Probit(),Prior_TDist(),1.0);
 
 m2_18.summaries
 
 m2_18.quantiles
 
 m2_19 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cloglog(),Prior_TDist(),1.0);
+                       ,ModelClass(:LogisticRegression),Cloglog(),Prior_TDist(),1.0);
 
 m2_19.summaries
 
 m2_19.quantiles
 
 m2_20 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cauchit(),Prior_TDist(),1.0);
+                       ,ModelClass(:LogisticRegression),Cauchit(),Prior_TDist(),1.0);
 
 m2_20.summaries
 
@@ -265,28 +265,28 @@ m2_20.quantiles
 **Logistic Regression - with Uniform Prior**
 ```@repl examples
 m2_21 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Logit(),Prior_Uniform(),1.0);
+                       ,ModelClass(:LogisticRegression),Logit(),Prior_Uniform(),1.0);
 
 m2_21.summaries
 
 m2_21.quantiles
 
 m2_22 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Probit(),Prior_Uniform(),1.0);
+                       ,ModelClass(:LogisticRegression),Probit(),Prior_Uniform(),1.0);
 
 m2_22.summaries
 
 m2_22.quantiles
 
 m2_23 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cloglog(),Prior_Uniform(),1.0);
+                       ,ModelClass(:LogisticRegression),Cloglog(),Prior_Uniform(),1.0);
 
 m2_23.summaries
 
 m2_23.quantiles
                 
 m2_24 = @fitmodel((Vote ~ Age + Race +Income + Educate),turnout
-                       ,LogisticRegression(),Cauchit(),Prior_Uniform(),1.0);
+                       ,ModelClass(:LogisticRegression),Cauchit(),Prior_Uniform(),1.0);
 
 m2_24.summaries
 
@@ -300,7 +300,7 @@ m2_24.quantiles
 ```@repl examples
 sanction = dataset("Zelig", "sanction")
 
-m3_1 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression());
+m3_1 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression));
 
 m3_1.fit
 
@@ -314,7 +314,7 @@ m3_1.BIC
 
 **Poisson Regression with Ridge Prior**
 ```@repl examples
-m3_2 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression(),Prior_Ridge());
+m3_2 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression),Prior_Ridge());
 
 m3_2.summaries
 
@@ -324,7 +324,7 @@ m3_2.quantiles
 
 **Poisson Regression with Laplace Prior**
 ```@repl examples
-m3_3 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression(),Prior_Laplace());
+m3_3 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression),Prior_Laplace());
 
 m3_3.summaries
 
@@ -334,7 +334,7 @@ m3_3.quantiles
 
 **Poisson Regression with Cauchy Prior**
 ```@repl examples
-m3_4 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression(),Prior_Cauchy());
+m3_4 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression),Prior_Cauchy());
 
 m3_4.summaries
 
@@ -344,7 +344,7 @@ m3_4.quantiles
 
 **Poisson Regression with TDist Prior**
 ```@repl examples
-m3_5 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression(),Prior_TDist());
+m3_5 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression),Prior_TDist());
 
 m3_5.summaries
 
@@ -354,7 +354,7 @@ m3_5.quantiles
 
 **Poisson Regression with Uniform Prior**
 ```@repl examples
-m3_6 = @fitmodel((Num ~ Target + Coop + NCost), sanction,PoissonRegression(),Prior_Uniform());
+m3_6 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:PoissonRegression),Prior_Uniform());
 
 m3_6.summaries
 
@@ -371,7 +371,7 @@ sanction = dataset("Zelig", "sanction")
 
 **Negative Binomial Regression - Likelihood method** 
 ```@repl examples
-m4_1 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression());
+m4_1 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression));
 
 m4_1.fit
 
@@ -383,7 +383,7 @@ m4_1.BIC
 
 **NegativeBinomial Regression with Ridge Prior**
 ```@repl examples
-m4_2 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression(),Prior_Ridge());
+m4_2 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression),Prior_Ridge());
 
 m4_2.summaries
 
@@ -393,7 +393,7 @@ m4_2.quantiles
 
 **NegativeBinomial Regression with Laplace Prior**
 ```@repl examples
-m4_3 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression(),Prior_Laplace());
+m4_3 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression),Prior_Laplace());
 
 m4_3.summaries
 
@@ -403,7 +403,7 @@ m4_3.quantiles
 
 **Negative Binomial Regression with Cauchy Prior**
 ```@repl examples
-m4_4 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression(),Prior_Cauchy())
+m4_4 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression),Prior_Cauchy())
 
 m4_4.summaries
 
@@ -413,7 +413,7 @@ m4_4.quantiles
 
 **Negative Binomial Regression with TDist Prior**
 ```@repl examples
-m4_5 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression(),Prior_TDist());
+m4_5 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression),Prior_TDist());
 
 m4_5.summaries
 
@@ -423,7 +423,7 @@ m4_5.quantiles
 
 **Negative Binomial Regression with Uniform Prior**
 ```@repl examples
-m4_6 = @fitmodel((Num ~ Target + Coop + NCost), sanction,NegBinomRegression(),Prior_Uniform(),1.0);
+m4_6 = @fitmodel((Num ~ Target + Coop + NCost), sanction,ModelClass(:NegBinomialRegression),Prior_Uniform(),1.0);
 
 m4_6.summaries
 

--- a/src/CRRao.jl
+++ b/src/CRRao.jl
@@ -24,10 +24,24 @@ using DataFrames, GLM, Turing, StatsModels
 using StatsBase, Distributions, LinearAlgebra
 using Optim, NLSolversBase, Random
 
-struct NegBinomRegression end
-struct PoissonRegression end
-struct LinearRegression end
-struct LogisticRegression end
+"""
+```julia
+ModelClass{modelclass}
+```
+
+Value type for models. Used in the `@fitmodel` macro for multiple dispatch over models. `modelclass` will a `Symbol`.
+"""
+struct ModelClass{modelclass} end
+
+"""
+```
+ModelClass(modelclass::Symbol) = ModelClass{modelclass}()
+```
+
+Constructor for `ModelClass`. Objects constructed this way will be passed as arguments to the `@fitmodel` macro. For examples refer to the examples for `fitmodel`.
+"""
+ModelClass(modelclass::Symbol) = ModelClass{modelclass}()
+
 struct Prior_Ridge end
 struct Prior_Laplace end
 struct Prior_Cauchy end
@@ -38,8 +52,7 @@ struct Probit end
 struct Cloglog end
 struct Cauchit end
 
-
-export LinearRegression, LogisticRegression, PoissonRegression, NegBinomRegression
+export ModelClass
 export Prior_Ridge, Prior_Laplace, Prior_Cauchy, Prior_TDist, Prior_Uniform
 export Logit, Probit, Cloglog, Cauchit, fitmodel, @fitmodel
 
@@ -49,7 +62,6 @@ include("LinearRegression.jl")
 include("LogisticRegression.jl")
 include("PoissonRegression.jl")
 include("NegBinomialRegression.jl")
-
 include("fitmodel.jl")
 
 end

--- a/src/fitmodel.jl
+++ b/src/fitmodel.jl
@@ -7,7 +7,7 @@
 
    1.  `formula` Provide the equation. Eg. `@formula(y~x1+x2+...)`
    2.  `data` Provide training data as `DataFrame``
-   3.  `modelClass`  : LinearRegression()
+   3.  `modelClass`  : ModelClass(:LinearRegression)
 
    ```Julia
 
@@ -15,7 +15,7 @@
 
    Julia> df = dataset("datasets", "mtcars");
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression());
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression));
 
    Julia> model.fit
 
@@ -75,7 +75,7 @@
    Julia> plot(model.Cooks_distance)
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression})
    ans = linear_reg(formula,data);
    ans
 end
@@ -96,7 +96,7 @@ end
       y ~ MvNormal(α .+ X * β, σ)
 
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression(),Prior_Ridge());
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression),Prior_Ridge());
 
    ┌ Info: Found initial step size
    └   ϵ = 0.003125
@@ -115,7 +115,7 @@ end
 
    ## All rhat values are close to 1; indicates convergence of Markov Chain.
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression,PriorMod::Prior_Ridge,h::Float64=0.01,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression},PriorMod::Prior_Ridge,h::Float64=0.01,sim_size::Int64=10000)
    ans = linear_reg(formula,data,Prior_Ridge(),h,sim_size);
    ans
 end
@@ -138,11 +138,11 @@ end
    # h is 0.01 as Default
    # sim_size is 10000
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression(),Prior_Laplace());
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression),Prior_Laplace());
 
    Alternative:
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression(),Prior_Laplace(),0.01,10000);
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression),Prior_Laplace(),0.01,10000);
 
    ┌ Warning: The current proposal will be rejected due to numerical error(s).
    │   isfinite.((θ, r, ℓπ, ℓκ)) = (true, false, false, false)
@@ -164,7 +164,7 @@ end
 
    ## All rhat values are close to 1; indicates convergence of Markov Chain.
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression,PriorMod::Prior_Laplace,h::Float64=0.01,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression},PriorMod::Prior_Laplace,h::Float64=0.01,sim_size::Int64=10000)
    ans = linear_reg(formula,data,Prior_Laplace(),h,sim_size);
    ans
 end
@@ -186,7 +186,7 @@ end
    # sim_size is 10000 (default). In the following example we considered 20000.
 
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression(),Prior_Cauchy(),20000);
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression),Prior_Cauchy(),20000);
 
    ┌ Info: Found initial step size
    └   ϵ = 0.00078125
@@ -204,7 +204,7 @@ end
 
    # All rhat values are close to 1; indicates convergence of Markov Chain.
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression,PriorMod::Prior_Cauchy,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression},PriorMod::Prior_Cauchy,sim_size::Int64=10000)
    ans = linear_reg(formula,data,Prior_Cauchy(),sim_size);
    ans
 end
@@ -226,7 +226,7 @@ end
 
    # sim_size is 10000 (default).
 
-   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,LinearRegression(),Prior_TDist());
+   Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df,ModelClass(:LinearRegression),Prior_TDist());
 
    ┌ Info: Found initial step size
    └   ϵ = 0.0001953125
@@ -265,7 +265,7 @@ end
    plot(model.chain)
 
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression,PriorMod::Prior_TDist,h::Float64=2.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression},PriorMod::Prior_TDist,h::Float64=2.0,sim_size::Int64=10000)
    ans = linear_reg(formula,data,Prior_TDist(),h,sim_size);
    ans
 end
@@ -286,14 +286,14 @@ end
    # sim_size is 10000 (default).
 
    Julia> model = @fitmodel(MPG ~ HP + WT+Gear,df
-                           ,LinearRegression()
+                           ,ModelClass(:LinearRegression)
                            ,Prior_Uniform());
 
    ## Check if trace-plots are stationary !
    Julia> plot(model.chain)
 
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LinearRegression,PriorMod::Prior_Uniform,h::Float64=0.01,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LinearRegression},PriorMod::Prior_Uniform,h::Float64=0.01,sim_size::Int64=10000)
    ans = linear_reg(formula,data,Prior_TDist(),h,sim_size);
    ans
 end
@@ -315,7 +315,7 @@ end
    Julia> turnout = dataset("Zelig", "turnout")
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                  ,turnout,LogisticRegression(),Logit());
+                  ,turnout,ModelClass(:LogisticRegression),Logit());
 
    Julia> model.fit
 
@@ -339,7 +339,7 @@ end
    2061.985776000826
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Logit)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Logit)
    ans = logistic_reg(formula,data,"LogitLink");
    ans
 end
@@ -363,7 +363,7 @@ end
    Julia> turnout = dataset("Zelig", "turnout")
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                  ,turnout,LogisticRegression(),Probit());
+                  ,turnout,ModelClass(:LogisticRegression),Probit());
    Julia> model.fit
 
    ────────────────────────────────────────────────────────────────────────────
@@ -377,7 +377,7 @@ end
    ────────────────────────────────────────────────────────────────────────────
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Probit)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Probit)
    ans = logistic_reg(formula,data,"ProbitLink");
    ans
 end
@@ -399,7 +399,7 @@ end
    Julia> turnout = dataset("Zelig", "turnout")
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                  ,turnout,LogisticRegression(),Cloglog());
+                  ,turnout,ModelClass(:LogisticRegression),Cloglog());
    Julia> model.fit
 
    ─────────────────────────────────────────────────────────────────────────────
@@ -413,7 +413,7 @@ end
    ─────────────────────────────────────────────────────────────────────────────
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Cloglog)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Cloglog)
    ans = logistic_reg(formula,data,"CloglogLink");
    ans
 end
@@ -435,7 +435,7 @@ end
       Julia> turnout = dataset("Zelig", "turnout")
 
       Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                     ,turnout,LogisticRegression(),Cauchit());
+                     ,turnout,ModelClass(:LogisticRegression),Cauchit());
       Julia> model.fit
 
       ────────────────────────────────────────────────────────────────────────────
@@ -449,7 +449,7 @@ end
       ────────────────────────────────────────────────────────────────────────────
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Cauchit)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Cauchit)
    ans = logistic_reg(formula,data,"CauchitLink");
    ans
 end
@@ -478,11 +478,11 @@ end
    Julia> turnout = dataset("Zelig", "turnout")
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                  ,turnout,LogisticRegression(),Cauchit());
+                  ,turnout,ModelClass(:LogisticRegression),Cauchit());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Logit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Logit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Logit(),Prior_Ridge(),h,sim_size)
    ans      
 end
@@ -509,12 +509,12 @@ end
    Julia> turnout = dataset("Zelig", "turnout")
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
-                  ,turnout,LogisticRegression()
+                  ,turnout,ModelClass(:LogisticRegression)
                   ,Probit(),Prior_Ridge());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Probit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Probit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Probit(),Prior_Ridge(),h,sim_size)
    ans      
 end
@@ -542,13 +542,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cloglog()
                            ,Prior_Ridge());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Cloglog,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Cloglog,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cloglog(),Prior_Ridge(),h,sim_size)
    ans      
 end
@@ -576,13 +576,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cauchit()
                            ,Prior_Ridge());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame,modelClass::LogisticRegression,Link::Cauchit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame,modelclass::ModelClass{:LogisticRegression},Link::Cauchit,PriorMod::Prior_Ridge, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cauchit(),Prior_Ridge(),h,sim_size)
    ans      
 end
@@ -610,13 +610,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Logit()
                            ,Prior_Laplace());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Logit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Logit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Logit(),Prior_Laplace(),h,sim_size)
    ans
 end
@@ -644,13 +644,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Probit()
                            ,Prior_Laplace());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Probit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Probit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Probit(),Prior_Laplace(),h,sim_size)
    ans
 end
@@ -678,13 +678,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cloglog()
                            ,Prior_Laplace());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cloglog, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cloglog, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cloglog(),Prior_Laplace(),h,sim_size)
    ans
 end
@@ -712,13 +712,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cauchit()
                            ,Prior_Laplace());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cauchit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cauchit, PriorMod::Prior_Laplace, h::Real=0.1, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cauchit(),Prior_Laplace(),h,sim_size)
    ans
 end
@@ -749,13 +749,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Logit()
                            ,Prior_Cauchy());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Logit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Logit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Logit(),Prior_Cauchy(),h,sim_size)
    ans
 end
@@ -784,13 +784,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Probit()
                            ,Prior_Cauchy());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Probit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Probit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Probit(),Prior_Cauchy(),h,sim_size)
    ans
 end
@@ -819,13 +819,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cloglog()
                            ,Prior_Cauchy());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cloglog, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cloglog, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cloglog(),Prior_Cauchy(),h,sim_size)
    ans
 end
@@ -854,13 +854,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cauchit()
                            ,Prior_Cauchy());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cauchit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cauchit, PriorMod::Prior_Cauchy, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cauchit(),Prior_Cauchy(),h,sim_size)
    ans
 end
@@ -891,13 +891,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Logit()
                            ,Prior_TDist());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Logit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Logit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Logit(),Prior_TDist(),h,sim_size)
    ans
 end
@@ -927,13 +927,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Probit()
                            ,Prior_TDist());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Probit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Probit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Probit(),Prior_TDist(),h,sim_size)
    ans
 end
@@ -963,13 +963,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cloglog()
                            ,Prior_TDist());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cloglog, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cloglog, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cloglog(),Prior_TDist(),h,sim_size)
    ans
 end
@@ -999,13 +999,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cauchit()
                            ,Prior_TDist());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cauchit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cauchit, PriorMod::Prior_TDist, h::Real=1.0, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cauchit(),Prior_TDist(),h,sim_size)
    ans
 end
@@ -1033,13 +1033,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Logit()
                            ,Prior_Uniform());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Logit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Logit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
   ans = logistic_reg(formula,data,Logit(),Prior_Uniform(),h,sim_size)
   ans     
 end
@@ -1067,13 +1067,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Probit()
                            ,Prior_Uniform());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Probit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Probit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Probit(),Prior_Uniform(),h,sim_size)
    ans     
 end
@@ -1101,13 +1101,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cloglog()
                            ,Prior_Uniform());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cloglog, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cloglog, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cloglog(),Prior_Uniform(),h,sim_size)
    ans     
 end
@@ -1136,13 +1136,13 @@ end
 
    Julia> model = @fitmodel(Vote ~ Age + Race +Income + Educate
                            ,turnout
-                           ,LogisticRegression()
+                           ,ModelClass(:LogisticRegression)
                            ,Cauchit()
                            ,Prior_Uniform());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LogisticRegression, Link::Cauchit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:LogisticRegression}, Link::Cauchit, PriorMod::Prior_Uniform, h::Real=0.01, level::Real=0.95, sim_size::Int64=10000)
    ans = logistic_reg(formula,data,Cauchit(),Prior_Uniform(),h,sim_size)
    ans     
 end
@@ -1167,11 +1167,11 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression());
+                           , ModelClass(:PoissonRegression));
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression})
    ans = Poisson_Reg(formula,data)
    ans     
 end
@@ -1201,12 +1201,12 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression()
+                           , ModelClass(:PoissonRegression)
                            , Prior_Ridge());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression,PriorMod::Prior_Ridge,h::Float64=0.1,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression},PriorMod::Prior_Ridge,h::Float64=0.1,sim_size::Int64=10000)
    ans = Poisson_Reg(formula,data,Prior_Ridge(),h,sim_size)
    ans
 end
@@ -1236,12 +1236,12 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression()
+                           , ModelClass(:PoissonRegression)
                            , Prior_Laplace());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression,PriorMod::Prior_Laplace,h::Float64=0.1,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression},PriorMod::Prior_Laplace,h::Float64=0.1,sim_size::Int64=10000)
    ans = Poisson_Reg(formula,data,Prior_Laplace(),h,sim_size)
    ans
 end
@@ -1270,12 +1270,12 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression()
+                           , ModelClass(:PoissonRegression)
                            , Prior_Cauchy());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression,PriorMod::Prior_Cauchy,h::Float64=1.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression},PriorMod::Prior_Cauchy,h::Float64=1.0,sim_size::Int64=10000)
    ans = Poisson_Reg(formula,data,Prior_Cauchy(),h,sim_size)
    ans
 end
@@ -1304,12 +1304,12 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression()
+                           , ModelClass(:PoissonRegression)
                            , Prior_TDist());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression,PriorMod::Prior_TDist,h::Float64=2.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression},PriorMod::Prior_TDist,h::Float64=2.0,sim_size::Int64=10000)
    ans = Poisson_Reg(formula,data,Prior_TDist(),h,sim_size)
    ans
 end
@@ -1339,12 +1339,12 @@ end
 
    Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                            , sanction
-                           , PoissonRegression()
+                           , ModelClass(:PoissonRegression)
                            , Prior_Uniform());
 
    ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::PoissonRegression,PriorMod::Prior_Uniform,h::Float64=1.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:PoissonRegression},PriorMod::Prior_Uniform,h::Float64=1.0,sim_size::Int64=10000)
    ans = Poisson_Reg(formula,data,Prior_Uniform(),h,sim_size)
    ans
 end
@@ -1375,7 +1375,7 @@ end
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression()
+                            , ModelClass(:NegBinomialRegression)
                             , Prior_Ridge());
 
     ┌ Info: Found initial step size
@@ -1396,7 +1396,7 @@ end
 
     ```
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression,PriorMod::Prior_Ridge,h::Float64=0.1,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression},PriorMod::Prior_Ridge,h::Float64=0.1,sim_size::Int64=10000)
     ans = NegBinom_Reg(formula,data,Prior_Ridge(),h,sim_size)
     ans
  end
@@ -1428,13 +1428,13 @@ function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomReg
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression()
+                            , ModelClass(:NegBinomialRegression)
                             , Prior_Laplace());
 
     ```
  
  """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression,PriorMod::Prior_Laplace,h::Float64=0.1,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression},PriorMod::Prior_Laplace,h::Float64=0.1,sim_size::Int64=10000)
     ans = NegBinom_Reg(formula,data,Prior_Laplace(),h,sim_size)
     ans
 end
@@ -1466,13 +1466,13 @@ end
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression()
+                            , ModelClass(:NegBinomialRegression)
                             , Prior_Cauchy());
 
     ```
  
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression,PriorMod::Prior_Cauchy,h::Float64=1.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression},PriorMod::Prior_Cauchy,h::Float64=1.0,sim_size::Int64=10000)
     ans = NegBinom_Reg(formula,data,Prior_Cauchy(),h,sim_size)
     ans
 end
@@ -1504,13 +1504,13 @@ end
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression()
+                            , ModelClass(:NegBinomialRegression)
                             , Prior_TDist());
 
     ```
  
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression,PriorMod::Prior_TDist,h::Float64=1.0,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression},PriorMod::Prior_TDist,h::Float64=1.0,sim_size::Int64=10000)
     ans = NegBinom_Reg(formula,data,Prior_TDist(),h,sim_size)
     ans
 end
@@ -1547,13 +1547,13 @@ end
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression()
+                            , ModelClass(:NegBinomialRegression)
                             , Prior_Uniform());
 
     ```
  
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression,PriorMod::Prior_Uniform,h::Float64=0.1,sim_size::Int64=10000)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression},PriorMod::Prior_Uniform,h::Float64=0.1,sim_size::Int64=10000)
     ans = NegBinom_Reg(formula,data,Prior_Uniform(),h,sim_size)
     ans
 end
@@ -1576,12 +1576,12 @@ end
     Julia> sanction = dataset("Zelig", "sanction");
     Julia> model = @fitmodel(Num ~ Target + Coop + NCost
                             , sanction
-                            , NegBinomRegression());
+                            , ModelClass(:NegBinomialRegression));
 
     ```
  
 """
-function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::NegBinomRegression)
+function fitmodel(formula::FormulaTerm, data::DataFrame, modelclass::ModelClass{:NegBinomialRegression})
     ans = NegBinom_Reg(formula,data,"LogLink")
     ans
 end
@@ -1597,7 +1597,7 @@ Macro for calling `fitmodel` without using `@formula` to create the formula.
 ```julia
 using CRRao, RDatasets
 sanction = dataset("Zelig", "sanction")
-model = @fitmodel(Num ~ Target + Coop + NCost, sanction, NegBinomRegression())
+model = @fitmodel(Num ~ Target + Coop + NCost, sanction, ModelClass(:NegBinomialRegression))
 ```
 """
 macro fitmodel(formula, args...)


### PR DESCRIPTION
Currently the package is declaring empty `struct`s to carry out multiple dispatch (examples are `NegBinomRegression`, `PoissonRegression` etc). While this is a way to do it, it introduces some problems: 

1) Addition of a new model will require declaration of a new empty `struct`, which is a lot of unnecessary code.
2) Calling the code requires calling an empty constructor like `LinearRegression()`, which might indicate to a user that the constructor might do something more than what it is doing.

To fix this problem, we can use [Julia's "value types"](https://docs.julialang.org/en/v1/manual/types/#%22Value-types%22). In particular, we add the following model and a "value" constructor. 

```julia
struct ModelClass{modelclass} end
ModelClass(modelclass::Symbol) = ModelClass{modelclass}()
```
Then, for example, we can replace `LinearRegression()` by `ModelClass(:LinearRegression)`; clearly the syntax is cleaner and is also suggestive of the fact that we are just specifying the type of the model.

The same thing can be done for link functions and priors. Also, it should be decided whether to export `ModelClass` or not; currently it is exported by the package. If it is decided not to, we can simply incorporate this in the `@fitmodel` macro (and then `LinearRegression()` will simply be replaced by the symbol `:LinearRegression`).