### PR TITLE
Using our own `aic` and `bic` instead of GLM's versions.

### DIFF
--- a/src/fitmodel.jl
+++ b/src/fitmodel.jl
@@ -3,16 +3,17 @@ Type to represent frequentist regression models returned by `fitmodel` functions
 """
 struct FrequentistRegression{RegressionType}
     model
+    ndims
 end
 
 """
 ```julia
-FrequentistRegression(::Symbol, model)
+FrequentistRegression(::Symbol, model, ndims)
 ```
 
 Constructor for `FrequentistRegression`. `model` can be any regression model. Used by `fitmodel` functions to return a frequentist regression model containers.
 """
-FrequentistRegression(RegressionType::Symbol, model) = FrequentistRegression{RegressionType}(model)
+FrequentistRegression(RegressionType::Symbol, model, ndims) = FrequentistRegression{RegressionType}(model, ndims)
 
 """
 Type to represent bayesian regression models returned by `fitmodel` functions. This type is used internally by the package to represent all bayesian regression models.

--- a/src/frequentist/getter.jl
+++ b/src/frequentist/getter.jl
@@ -15,11 +15,14 @@ function loglikelihood(container::FrequentistRegression)
 end
 
 function aic(container::FrequentistRegression)
-    return StatsBase.aic(container.model)
+    # container.ndims[2] is the number of parameters
+    return (2 * container.ndims[2] - 2 * loglikelihood(container))
 end
 
 function bic(container::FrequentistRegression)
-    return StatsBase.bic(container.model)
+    # container.ndims[1] is the number of data points
+    # container.ndims[2] is the number of parameters
+    return (log(container.ndims[1]) * container.ndims[2] - 2 * loglikelihood(container))
 end
 
 function sigma(container::FrequentistRegression)

--- a/src/frequentist/linear_regression.jl
+++ b/src/frequentist/linear_regression.jl
@@ -52,6 +52,11 @@ julia> plot(cooksdistance(container));
 """
 function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LinearRegression)
     formula = apply_schema(formula, schema(formula, data))
+    y, X = modelcols(formula, data)
+    fm_frame = ModelFrame(formula,data)
+    X = modelmatrix(fm_frame)
+
     model = lm(formula, data)
-    return FrequentistRegression(:LinearRegression, model)
+    ndims = (size(X, 1), size(X, 2))
+    return FrequentistRegression(:LinearRegression, model, ndims)
 end

--- a/src/frequentist/linear_regression.jl
+++ b/src/frequentist/linear_regression.jl
@@ -57,6 +57,6 @@ function fitmodel(formula::FormulaTerm, data::DataFrame, modelClass::LinearRegre
     X = modelmatrix(fm_frame)
 
     model = lm(formula, data)
-    ndims = (size(X, 1), size(X, 2))
+    ndims = (size(X, 1), size(X, 2) + 1)
     return FrequentistRegression(:LinearRegression, model, ndims)
 end

--- a/src/frequentist/logistic_regression.jl
+++ b/src/frequentist/logistic_regression.jl
@@ -26,8 +26,13 @@ end
 
 function logistic_reg(formula::FormulaTerm, data::DataFrame, Link::GLM.Link)
     formula = apply_schema(formula, schema(formula, data))
+    y, X = modelcols(formula, data)
+    fm_frame=ModelFrame(formula,data)
+    X = modelmatrix(fm_frame)
+
     model = glm(formula, data, Binomial(), Link)
-    return FrequentistRegression(:LogisticRegression, model)
+    ndims = (size(X, 1), size(X, 2))
+    return FrequentistRegression(:LogisticRegression, model, ndims)
 end
 
 """

--- a/src/frequentist/negativebinomial_regression.jl
+++ b/src/frequentist/negativebinomial_regression.jl
@@ -17,8 +17,13 @@ end
 
 function negativebinomial_reg(formula::FormulaTerm, data::DataFrame, Link::GLM.Link)
     formula = apply_schema(formula, schema(formula, data))
+    y, X = modelcols(formula, data)
+    fm_frame = ModelFrame(formula,data)
+    X = modelmatrix(fm_frame)
+
     model = glm(formula, data, NegativeBinomial(), Link)
-    return FrequentistRegression(:NegativeBinomialRegression, model)
+    ndims = (size(X, 1), size(X, 2))
+    return FrequentistRegression(:NegativeBinomialRegression, model, ndims)
 end
 
 """

--- a/src/frequentist/poisson_regression.jl
+++ b/src/frequentist/poisson_regression.jl
@@ -10,8 +10,13 @@ end
 
 function poisson_reg(formula::FormulaTerm, data::DataFrame, Link::GLM.Link)
     formula = apply_schema(formula, schema(formula, data))
+    y, X = modelcols(formula, data)
+    fm_frame = ModelFrame(formula,data)
+    X = modelmatrix(fm_frame)
+
     model = glm(formula, data, Poisson(), Link)
-    return FrequentistRegression(:PoissonRegression, model)
+    ndims = (size(X, 1), size(X, 2))
+    return FrequentistRegression(:PoissonRegression, model, ndims)
 end
 
 """


### PR DESCRIPTION
This PR is to fix revert back to our own implementations of `aic` and `bic` functions (from the older code, till commit e66244f05728845db92be2e1d4f459e0f3894691) instead of using the GLM versions of those functions. The formula for computing the AIC of a frequentist model is 
$$\text{aic} = 2\cdot p - 2\cdot\text{loglikelihood}$$
where $$p$$ is the number of parameters of the model, and $$\text{loglikelihood}$$ is the log-likelihood of the model.

The formula for computing the BIC of a frequentist model is 
$$\text{bic} = \log(n)\cdot p - 2\cdot \text{loglikelihood}$$
where $$n$$ is the number of datapoints. 

Instead of $p$, GLM uses $k$, consumed degrees of freedom. 

We have added a property `ndims` to the `FrequentistRegression` struct; `ndims` is a tuple containing the dimensions of the dataset on which the model was trained. So, `ndims[1]` is the number of points in the dataset, and `ndims[2]` is the number of parameters in the model.

In the older code (till commit e66244f05728845db92be2e1d4f459e0f3894691), the number of parameters for the frequentist linear regression model was `size(X, 2) + 1`; for other models, it was just `size(X, 2)`. We have kept this in mind and made the relevant changes in the file (for instance, look at `src/frequentist/linear_regression.jl` line 60).