### PR TITLE
Update Base.show for BayesianRegression to print formula and link

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -28,5 +28,8 @@ end
 
 # Bayesian Models
 function Base.show(io::IO, container::BayesianRegression)
+    println(io, "Formula: ", container.formula)
+    println(io, "Link: ", container.link)
+    print(io, "Chain: ")
     show(io, MIME("text/plain"), container.chain)
 end


### PR DESCRIPTION
@ayushpatnaikgit 
This PR updates Base.show for BayesianRegression to print formula and link.

Example:
```Julia
using CRRao, RDatasets, StatsModels;
df = dataset("datasets", "mtcars");
container = fit(@formula(MPG ~ HP + WT + Gear), df, LinearRegression(), Prior_Ridge());
println(container);
```
gives
```
Formula: MPG ~ 1 + HP + WT + Gear
Link: CRRao.Identity(CRRao.Identity_Link)
Chain: Chains MCMC chain (1000×18×1 Array{Float64, 3}):

Iterations        = 501:1:1500
Number of chains  = 1
Samples per chain = 1000
Wall duration     = 21.67 seconds
Compute duration  = 21.67 seconds
parameters        = v, σ, β[1], β[2], β[3], β[4]
internals         = lp, n_steps, is_accept, acceptance_rate, log_density, hamiltonian_energy, hamiltonian_energy_error, max_hamiltonian_energy_error, tree_depth, numerical_error, step_size, nom_step_size

Summary Statistics
  parameters      mean       std   naive_se      mcse        ess      rhat   ess_per_sec 
      Symbol   Float64   Float64    Float64   Float64    Float64   Float64       Float64 

           v    6.7021    4.0491     0.1280    0.2195   315.8915    1.0032       14.5753
           σ    2.7274    0.4085     0.0129    0.0218   354.4693    0.9991       16.3553
        β[1]   28.0797    5.7386     0.1815    0.3680   292.6875    1.0019       13.5047
        β[2]   -0.0396    0.0112     0.0004    0.0005   457.8996    1.0008       21.1277
        β[3]   -2.6558    1.0297     0.0326    0.0547   351.8371    1.0017       16.2339
        β[4]    1.7175    1.0346     0.0327    0.0664   293.7995    1.0015       13.5560

Quantiles
  parameters      2.5%     25.0%     50.0%     75.0%     97.5% 
      Symbol   Float64   Float64   Float64   Float64   Float64 

           v    2.2010    4.2551    5.7929    7.9132   16.6991
           σ    2.0689    2.4365    2.6797    2.9649    3.6223
        β[1]   15.2404   24.4120   28.4586   31.9295   38.2677
        β[2]   -0.0631   -0.0466   -0.0396   -0.0318   -0.0197
        β[3]   -4.5106   -3.3403   -2.6919   -2.0135   -0.5729
        β[4]   -0.1272    0.9899    1.6524    2.3756    3.8824
```