### PR TITLE
Change version to `0.1.1` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Milestones](https://img.shields.io/badge/-milestones-brightgreen)](https://github.com/xKDR/CRRao.jl/milestones)
 
 ## To install: 
-### For version 0.1.0 (stable)
+### For version 0.1.1 (stable)
 ```Julia
 using Pkg; Pkg.add("CRRao")
 ```


### PR DESCRIPTION
Fixes #148.

Change
### ```For version 0.1.0 (stable)```
to
### ```For version 0.1.1 (stable)```
